### PR TITLE
fix issue TypeError: error.getPrimaryResultCode is not a function

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -274,14 +274,7 @@ export class NodeSqliteError extends Error implements NodeSqliteErrorData {
  * Type guard to check if an error is a NodeSqliteError
  */
 export function isNodeSqliteError(error: unknown): error is NodeSqliteError {
-	return (
-		error instanceof NodeSqliteError ||
-		(error instanceof Error &&
-			"code" in error &&
-			"errcode" in error &&
-			"errstr" in error &&
-			error.code === "ERR_SQLITE_ERROR")
-	);
+	return (error instanceof NodeSqliteError)
 }
 
 /**


### PR DESCRIPTION
I encountered an issue with broken error handling in Node 23.9.0. Instead of receiving the proper error from SQLite, I received the following error:

`TypeError: error.getPrimaryResultCode is not a function.`

Additionally, some of the tests did not pass, so not all tests are green, and the error handling is functioning as expected.


Test case about which Im speaking:
```
test at src/index.test.ts:1:3161
✖ constraints and error handling (1.765375ms)
  AssertionError [ERR_ASSERTION]: The input did not match the regular expression /UNIQUE constraint failed/. Input:
  
  'TypeError: error.getPrimaryResultCode is not a function'
  
      at async TestContext.<anonymous> (/Users/fin/dev/external/kysely-node-sqlite/src/index.test.ts:194:3)
      at async Test.run (node:internal/test_runner/test:1054:7)
      at async Suite.processPendingSubtests (node:internal/test_runner/test:744:7) {
    generatedMessage: true,
    code: 'ERR_ASSERTION',
    actual: TypeError: error.getPrimaryResultCode is not a function
        at SqliteConnection.executeQuery (/Users/fin/dev/external/kysely-node-sqlite/src/index.ts:494:12)
        at file:///Users/fin/dev/external/kysely-node-sqlite/node_modules/.pnpm/kysely@0.27.5/node_modules/kysely/dist/esm/query-executor/query-executor-base.js:35:45
        at DefaultConnectionProvider.provideConnection (file:///Users/fin/dev/external/kysely-node-sqlite/node_modules/.pnpm/kysely@0.27.5/node_modules/kysely/dist/esm/driver/default-connection-provider.js:10:26)
        at async DefaultQueryExecutor.executeQuery (file:///Users/fin/dev/external/kysely-node-sqlite/node_modules/.pnpm/kysely@0.27.5/node_modules/kysely/dist/esm/query-executor/query-executor-base.js:34:16)
        at async InsertQueryBuilder.execute (file:///Users/fin/dev/external/kysely-node-sqlite/node_modules/.pnpm/kysely@0.27.5/node_modules/kysely/dist/esm/query-builder/insert-query-builder.js:916:24)
        at async waitForActual (node:assert:875:5)
        at async Function.rejects (node:assert:996:25)
        at async TestContext.<anonymous> (/Users/fin/dev/external/kysely-node-sqlite/src/index.test.ts:194:3)
        at async Test.run (node:internal/test_runner/test:1054:7)
        at async Suite.processPendingSubtests (node:internal/test_runner/test:744:7),
    expected: /UNIQUE constraint failed/,
    operator: 'rejects'
  }

```